### PR TITLE
Add log flags for configurable logging levels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,12 @@ ENV MOBILE_ENABLED=""
 ENV MOBILE_TITLE=""
 ENV MOBILE_WS_URL=""
 
+ENV LOG_QUIET=""
+ENV LOG_VERBOSE=""
+
+ENV PYTHONPATH="/opt/mopidy-venv"
+ENV PATH="/opt/mopidy-venv/bin:$PATH"
+
 COPY app/bin/entrypoint.sh /app/bin/
 RUN chmod +x /app/bin/entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ USER_MODE|Set to `yes` to enable user mode
 PUID|The uid for `USER_MODE`, defaults to `1000`
 PGID|The gid for `USER_MODE`, defaults to `1000`
 AUDIO_GID|Group id for `USER_MODE`, set it to the group id of the group `audio` if `USER_MODE` is enabled
+LOG_LEVEL|0: quiet, 1: default, 2: verbose
 
 ### Volumes
 

--- a/app/bin/entrypoint.sh
+++ b/app/bin/entrypoint.sh
@@ -148,7 +148,21 @@ if [[ -n "${RESTORE_STATE}" ]]; then
     fi
 fi
 
-COMMAND_LINE="$COMMAND_LINE --config $CONFIG_DIR --option core/cache_dir=${CACHE_DIR} --option core/data_dir=${DATA_DIR}"
+LOG_SWITCH=""
+if [[ -n "${LOG_LEVEL}" ]]; then
+    if [[ "$LOG_LEVEL" -eq 0 ]]; then
+        LOG_SWITCH="-q"
+    elif [[ "$LOG_LEVEL" -eq 1 ]]; then
+        LOG_SWITCH=""
+    elif [[ "$LOG_LEVEL" -eq 2 ]]; then
+        LOG_SWITCH="-v"
+    else
+        echo "Invalid LOG_LEVEL=[$LOG_LEVEL]"
+        exit 1
+    fi
+fi
+
+COMMAND_LINE="$COMMAND_LINE $LOG_SWITCH --config $CONFIG_DIR --option core/cache_dir=${CACHE_DIR} --option core/data_dir=${DATA_DIR}"
 
 # IRIS web gui
 echo "[iris]" > $CONFIG_DIR/iris.conf


### PR DESCRIPTION
* Introduce environment variables for log levels
* Add `PATH` variable to final image.  This ensures that running `mopidy` commands (such as `docker compose exec mopidy mopidy local scan`)  via `docker-compose` runs the correct binary in `PYTHONPATH/bin`, without the user having to explicitly specify the full path.  